### PR TITLE
Improves readability of spec page

### DIFF
--- a/static/css/rtmp.css
+++ b/static/css/rtmp.css
@@ -321,36 +321,36 @@ figcaption {
 }
 
 .tk-content h1 {
-  color: #4c4c4c;
   font-size: 3rem;
   line-height: 1.25;
   padding-top: 1rem;
 }
 .tk-content h2 {
-  color: #4c4c4c;
   font-size: 2.25rem;
   line-height: 1.25;
-  margin-top: 1rem;
+  margin-top: 3rem;
 }
 .tk-content h3 {
   border-bottom: 1px solid black;
-  font-size: 1.1rem;
+  font-size: 1.5rem;
+  font-variant: small-caps;
   line-height: 1.25;
-  margin-top: .8rem;
-  text-transform: uppercase;
+  margin-top: 2.5rem;
+  text-transform: lowercase;
 }
 .tk-content h4,
 .tk-content h5 {
-  font-size: 1.1rem;
+  font-size: 1rem;
+  font-weight: 700;
   line-height: 1.25;
-  margin-top: .8rem;
+  margin-top: 2.5rem;
 }
 
 .tk-content h6 {
   font-size: 1rem;
   font-weight: 700;
   line-height: 1.25;
-  margin-top: .8rem;
+  margin-top: 1rem;
   text-transform: uppercase;
 }
 

--- a/static/css/rtmp.css
+++ b/static/css/rtmp.css
@@ -315,6 +315,11 @@ figcaption {
   transition: fill 0.4s ease;
 }
 
+.tk-content strong {
+  color: #4c4c4c;
+  font-variant: small-caps;
+}
+
 .tk-content svg:hover,
 .tk-content svg:focus {
   fill: #ce0201;


### PR DESCRIPTION
For #7.

Before, the typography (in particular of headings) was a leeeettle crunched, making it hard to find sections of the long spec. Also, the style for `<strong>` was essentially the same as the style for `h4` and `h5`, making the text hard to scan. This PR submits a few tidying-up styles to improve these issues.

**Before**
![Screenshot 2020-01-28 18 45 54](https://user-images.githubusercontent.com/4827522/73244835-fb30cf00-41fe-11ea-98e2-2e1c09c9b467.png)

**After**
![Screenshot 2020-01-28 18 46 09](https://user-images.githubusercontent.com/4827522/73244806-e94f2c00-41fe-11ea-8c27-b6da5fcb0595.png)

---

**Before**
![Screenshot 2020-01-28 18 46 43](https://user-images.githubusercontent.com/4827522/73244964-3cc17a00-41ff-11ea-9ed7-9c72b5638f6a.png)

**After**
![Screenshot 2020-01-28 18 46 50](https://user-images.githubusercontent.com/4827522/73244969-3fbc6a80-41ff-11ea-8608-c907c5076568.png)