### PR TITLE
add links & illustrate all the bits to clarify cs id

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -63,21 +63,21 @@ RTMP spec, section 6.1
     ---------------------------------------------------------------------
 ```
 
-* 01: [SetChunkSize](../spec/#541set-chunk-size-1)
-* 02: [Abort](../spec/#542abort-message-2)
-* 03: [Ack](../spec/#543acknowledgement-3)
-* 04: [User Control Message](../spec/#62-user-control-messages-4)
-* 05: [Window Ack Size](../spec/#544window-acknowledgement-size-5)
-* 06: [Peer Bandwidth](../spec/#545set-peer-bandwidth-6)
-* 08: [Audio Message](../spec/#714audio-message-8)
-* 09: [Video Message](../spec/#715video-message-9)
-* 15: [Data Message](../spec/#712data-message-18-15) (AMF3)
-* 16: [Shared Object Message](../spec/#713shared-object-message-19-16) (AMF3)
-* 17: [Command Message](../spec/#711command-message-20-17) (AMF3)
-* 18: [Data Message](../spec/#712data-message-18-15) (AMF0)
-* 19: [Shared Object Message](../spec/#713shared-object-message-19-16) (AMF0)
-* 20: [Command Message](../spec/#711command-message-20-17) (AMF0)
-* 22: [Aggregate Message](../spec/#716aggregate-message-22)
+* 01: [SetChunkSize](/docs/spec/#541set-chunk-size-1)
+* 02: [Abort](/docs/spec/#542abort-message-2)
+* 03: [Ack](/docs/spec/#543acknowledgement-3)
+* 04: [User Control Message](/docs/spec/#62-user-control-messages-4)
+* 05: [Window Ack Size](/docs/spec/#544window-acknowledgement-size-5)
+* 06: [Peer Bandwidth](/docs/spec/#545set-peer-bandwidth-6)
+* 08: [Audio Message](/docs/spec/#714audio-message-8)
+* 09: [Video Message](/docs/spec/#715video-message-9)
+* 15: [Data Message](/docs/spec/#712data-message-18-15) (AMF3)
+* 16: [Shared Object Message](/docs/spec/#713shared-object-message-19-16) (AMF3)
+* 17: [Command Message](/docs/spec/#711command-message-20-17) (AMF3)
+* 18: [Data Message](/docs/spec/#712data-message-18-15) (AMF0)
+* 19: [Shared Object Message](/docs/spec/#713shared-object-message-19-16) (AMF0)
+* 20: [Command Message](/docs/spec/#711command-message-20-17) (AMF0)
+* 22: [Aggregate Message](/docs/spec/#716aggregate-message-22)
 
 ### Initial Connection Sequence
 

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -63,21 +63,21 @@ RTMP spec, section 6.1
     ---------------------------------------------------------------------
 ```
 
-* 01: SetChunkSize
-* 02: Abort
-* 03: Ack Chunk
-* 04: User Control Message
-* 05: Window Ack Size
-* 06: Peer Bandwidth
-* 08: Audio Message
-* 09: Video Message
-* 15: Data Message (AMF3)
-* 16: Shared Object Message (AMF3)
-* 17: Command Message (AMF3)
-* 18: Data Message (AMF0)
-* 19: Shared Object Message (AMF0)
-* 20: Command Message (AMF0)
-* 22: Aggregate Message
+* 01: [SetChunkSize](../spec/#541set-chunk-size-1)
+* 02: [Abort](../spec/#542abort-message-2)
+* 03: [Ack](../spec/#543acknowledgement-3)
+* 04: [User Control Message](../spec/#62-user-control-messages-4)
+* 05: [Window Ack Size](../spec/#544window-acknowledgement-size-5)
+* 06: [Peer Bandwidth](../spec/#545set-peer-bandwidth-6)
+* 08: [Audio Message](../spec/#714audio-message-8)
+* 09: [Video Message](../spec/#715video-message-9)
+* 15: [Data Message](../spec/#712data-message-18-15) (AMF3)
+* 16: [Shared Object Message](../spec/#713shared-object-message-19-16) (AMF3)
+* 17: [Command Message](../spec/#711command-message-20-17) (AMF3)
+* 18: [Data Message](../spec/#712data-message-18-15) (AMF0)
+* 19: [Shared Object Message](../spec/#713shared-object-message-19-16) (AMF0)
+* 20: [Command Message](../spec/#711command-message-20-17) (AMF0)
+* 22: [Aggregate Message](../spec/#716aggregate-message-22)
 
 ### Initial Connection Sequence
 

--- a/content/docs/spec.md
+++ b/content/docs/spec.md
@@ -303,7 +303,7 @@ Chunk stream IDs 64-319 can be encoded in the 2-byte form of the header. ID is c
  0                   1
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|fmt|     0     |   cs id - 64  |
+|fmt|0 0 0 0 0 0|   cs id - 64  |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 <figcaption>Chunk basic header 2</figcaption>
@@ -314,7 +314,7 @@ Chunk stream IDs 64-65599 can be encoded in the 3-byte version of this field. ID
 <figure><pre>
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|fmt|     1     |          cs id - 64           |
+|fmt|0 0 0 0 0 1|          cs id - 64           |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 <figcaption>Chunk basic header 3</figcaption>

--- a/content/docs/spec.md
+++ b/content/docs/spec.md
@@ -286,6 +286,9 @@ The protocol supports up to 65597 streams with IDs 3-65599. The IDs 0, 1, and 2 
 
 The bits 0-5 (least significant) in the chunk basic header represent the chunk stream ID.
 
+
+###### 1 Byte
+
 Chunk stream IDs 2-63 can be encoded in the 1-byte version of this field.
 
 <figure><pre>
@@ -296,6 +299,9 @@ Chunk stream IDs 2-63 can be encoded in the 1-byte version of this field.
 </pre>
 <figcaption>Chunk basic header 1</figcaption>
 </figure>
+
+
+###### 2 Bytes
 
 Chunk stream IDs 64-319 can be encoded in the 2-byte form of the header. ID is computed as (the second byte + 64).
 
@@ -308,6 +314,8 @@ Chunk stream IDs 64-319 can be encoded in the 2-byte form of the header. ID is c
 </pre>
 <figcaption>Chunk basic header 2</figcaption>
 </figure>
+
+###### 3 Bytes
 
 Chunk stream IDs 64-65599 can be encoded in the 3-byte version of this field. ID is computed as ((the third byte)\*256 + (the second byte) + 64).
 


### PR DESCRIPTION
I think it is a bit more readable to fill in all the bits for the `cs id` when it is `0` or `1`
also added links to overview (which prolly should have been in diff PR, but will leave together unless there's some objection)