### PR TITLE
add links to RTMP Errata and Addenda document

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -12,6 +12,7 @@ recorded video, as well as broadcast streaming, video on demand (VOD) use cases.
 - [RTMFP](https://tools.ietf.org/html/rfc7425), IETF Independent Submission, Category: Informational, December 2014</li>
 - [Adobe RTMP Specification](/docs/spec/) (HTML)
 - [Adobe RTMP Specification](https://www.adobe.com/content/dam/acom/en/devnet/rtmp/pdf/rtmp_specification_1.0.pdf) (PDF)
+- [RTMP Errata and Addenda (HTML)](https://zenomt.github.io/rtmp-errata-addenda/rtmp-errata-addenda.html) [(Plain Text)](https://zenomt.github.io/rtmp-errata-addenda/rtmp-errata-addenda.txt) [(Source)](https://github.com/zenomt/rtmp-errata-addenda)
 
 ### Related File Formats
 

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -12,7 +12,6 @@ recorded video, as well as broadcast streaming, video on demand (VOD) use cases.
 - [RTMFP](https://tools.ietf.org/html/rfc7425), IETF Independent Submission, Category: Informational, December 2014</li>
 - [Adobe RTMP Specification](/docs/spec/) (HTML)
 - [Adobe RTMP Specification](https://www.adobe.com/content/dam/acom/en/devnet/rtmp/pdf/rtmp_specification_1.0.pdf) (PDF)
-- [RTMP Errata and Addenda (HTML)](https://zenomt.github.io/rtmp-errata-addenda/rtmp-errata-addenda.html) ([Plain Text](https://zenomt.github.io/rtmp-errata-addenda/rtmp-errata-addenda.txt)) ([Source](https://github.com/zenomt/rtmp-errata-addenda))
 
 ### Related File Formats
 
@@ -30,3 +29,7 @@ recorded video, as well as broadcast streaming, video on demand (VOD) use cases.
 - [Adobe’s Real Time Messaging Protocol](/pdf/rtmp_specification_1.0.pdf) (PDF)
 - [Video File Format Specification Version 10](/pdf/video_file_format_spec_v10.pdf) (PDF)
 - [Adobe Flash Video File Format Specification Version 10.1](/pdf/video_file_format_spec_v10_1.pdf) (PDF)
+
+### Other Resources
+
+- [RTMP Errata and Addenda (HTML)](https://zenomt.github.io/rtmp-errata-addenda/rtmp-errata-addenda.html) ([Plain Text](https://zenomt.github.io/rtmp-errata-addenda/rtmp-errata-addenda.txt)) ([Source](https://github.com/zenomt/rtmp-errata-addenda))

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -12,7 +12,7 @@ recorded video, as well as broadcast streaming, video on demand (VOD) use cases.
 - [RTMFP](https://tools.ietf.org/html/rfc7425), IETF Independent Submission, Category: Informational, December 2014</li>
 - [Adobe RTMP Specification](/docs/spec/) (HTML)
 - [Adobe RTMP Specification](https://www.adobe.com/content/dam/acom/en/devnet/rtmp/pdf/rtmp_specification_1.0.pdf) (PDF)
-- [RTMP Errata and Addenda (HTML)](https://zenomt.github.io/rtmp-errata-addenda/rtmp-errata-addenda.html) [(Plain Text)](https://zenomt.github.io/rtmp-errata-addenda/rtmp-errata-addenda.txt) [(Source)](https://github.com/zenomt/rtmp-errata-addenda)
+- [RTMP Errata and Addenda (HTML)](https://zenomt.github.io/rtmp-errata-addenda/rtmp-errata-addenda.html) ([Plain Text](https://zenomt.github.io/rtmp-errata-addenda/rtmp-errata-addenda.txt)) ([Source](https://github.com/zenomt/rtmp-errata-addenda))
 
 ### Related File Formats
 


### PR DESCRIPTION
This PR adds links to [_RTMP Errata and Addenda_](https://github.com/zenomt/rtmp-errata-addenda), a collection of corrections, clarifications, and amendments to the historical RTMP Specification of December 2012 (of which I am one of the listed authors/editors, though no longer at Adobe).